### PR TITLE
Add HTML category and retina-spacer-gif suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ For now this is a really short list, so please contribute. Read [the guide](CONT
 - [Elixir](#elixir)
 - [Golang](#golang)
 - [Haskell](#haskell)
+- [HTML](#html)
 - [Java](#java)
 - [JavaScript](#javascript)
 - [PHP](#php)
@@ -42,6 +43,8 @@ For now this is a really short list, so please contribute. Read [the guide](CONT
 ## Haskell
 - [hackertyper](https://github.com/fgaz/hackertyper) - "Hack" like a programmer in movies and games!
 
+## HTML
+- [retina-spacer-gif](https://github.com/ao5357/retina-spacer-gif) - Spacer gif for retina displays
 
 ## Java
 


### PR DESCRIPTION
## What does this project do?

This project provides an drop-in replacement spacer gif for projects that want to be compatible with high pixel-density displays, also known as 'retina' displays. When Apple introduced the iPhone 4 in 2010, it created a need to update sites using spacer gifs to the @2x crisper version.

## Why is that entertaining?

Spacer gifs were historically transparent, or took the color of their surroundings. A larger spacer gif cramming four pixels of information into a single pixel changes nothing about a legacy webpage.

In the README I tried to make some tongue-in-cheek jokes about outmoded hosting and negligible performance concerns. The "Is it HTML5 compatible?" section contains a DTD and a meta tag that virtually guarantee setting browsers [that still support it] into quirks mode; something you'd only understand and appreciate if you know _way_ too much about HTML and browser history. Additionally, it's ridiculous to use an SVG on a page that would conceivably use a spacer gif. Maybe a site using a retina tracking pixel, but not a spacer gif!

## How hard did you laugh? Was it just a silent giggle or was it full blown laughing and howling and screaming "OH MY GOD! EVERYONE! OH MY GOD! THIS IS THE FUNNIEST THING EVER! YOU'VE GOT TO SEE THIS!!!"

This is my joke. Very few people have appreciated it over the years. I'm asking you to take pity on my dumb sense of humor.
